### PR TITLE
Define owner and file permissions for LightDM config file

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,6 +13,9 @@
   template:
     src: lightdm.conf.j2
     dest: "{{ lightdm_conf_directory }}/{{ lightdm_overide_filename }}"
+    owner: root
+    group: root
+    mode: 'u=rw,go=r'
 
 - name: apply glib schemas changes
   command: "/usr/bin/glib-compile-schemas {{ lightdm_glib_schemas_directory }}"


### PR DESCRIPTION
While the defaults work it's best to be explicit.
