### PR TITLE
Declared Ubuntu Trusty and Xenial as supported

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -7,7 +7,9 @@ galaxy_info:
   platforms:
   - name: Ubuntu
     versions:
+    - trusty
     - wily
+    - xenial
   galaxy_tags:
     - lightdm
     - autologin


### PR DESCRIPTION
Updated Ansible Galaxy Metadata.

Enhancement: resolves #8
