### PR TITLE
Added ansible_managed header to template file

### DIFF
--- a/templates/lightdm.conf.j2
+++ b/templates/lightdm.conf.j2
@@ -1,3 +1,5 @@
+# {{ ansible_managed }}
+
 [SeatDefaults]
 {% if lightdm_autologin_user %}
 autologin-user={{ lightdm_autologin_user }}


### PR DESCRIPTION
This is useful to tell users that a file has been placed by Ansible and manual changes are likely to be overwritten.
