### PR TITLE
Only install apt dependencies if apt is available

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-- name: install dependencies
+- name: install dependencies (apt)
   become: yes
   apt:
     name: '{{ item }}'
@@ -7,6 +7,7 @@
   with_items:
     - lightdm
     - libglib2.0-bin
+  when: ansible_pkg_mgr == 'apt'
 
 - name: enable auto-login
   become: yes


### PR DESCRIPTION
This will allow the role to work on other distributions as long as the dependencies are already satisfied.