### PR TITLE
Run CI build when tags are pushed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,6 +51,7 @@ script:
 branches:
   only:
     - master
+    - /^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)([\.\-].*)?$/
 
 notifications:
   webhooks: https://galaxy.ansible.com/api/v1/notifications/


### PR DESCRIPTION
CI builds are needed when tags are pushed so the notification get sent to
Ansible Galaxy.