### PR TITLE
Reverted handler back to task

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,4 +1,2 @@
 ---
-- name: compile glib schemas
-  become: yes
-  command: '/usr/bin/glib-compile-schemas {{ lightdm_glib_schemas_directory }}'
+# handlers file for lightdm

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -20,6 +20,11 @@
   register: lightdm_config
 
 - name: apply glib schemas changes
+  tags:
+    # Suppress warning: [ANSIBLE0016] Tasks that run when changed should likely be handlers
+    # Since the command is invoked with an argument that is role specific it
+    # doesn't make sense to use a handler, which are global to the playbook.
+    - skip_ansible_lint
   become: yes
   command: '/usr/bin/glib-compile-schemas {{ lightdm_glib_schemas_directory }}'
   when: lightdm_config.changed

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -17,5 +17,9 @@
     owner: root
     group: root
     mode: 'u=rw,go=r'
-  notify:
-    - compile glib schemas
+  register: lightdm_config
+
+- name: apply glib schemas changes
+  become: yes
+  command: '/usr/bin/glib-compile-schemas {{ lightdm_glib_schemas_directory }}'
+  when: lightdm_config.changed


### PR DESCRIPTION
Since the command is invoked with an argument that is role specific it doesn't make sense to use a handler, which are global to the playbook.