### PR TITLE
Changed example role to pure YAML syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,8 @@ This role can be used as follows:
 ```yaml
 - hosts: servers
   roles:
-     - { role: gantsign.lightdm, lightdm_autologin_user: vagrant }
+    - role: gantsign.lightdm
+      lightdm_autologin_user: vagrant
 ```
 
 More Roles From GantSign


### PR DESCRIPTION
Using the hybrid YAML/JSON syntax is potentially confusing to new users as it's not clear whether this peculiar syntax is a requirement or not.