### PR TITLE
Changed tests to use host fixture

### DIFF
--- a/molecule/default/tests/test_role.py
+++ b/molecule/default/tests/test_role.py
@@ -6,12 +6,12 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
     os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('all')
 
 
-def test_lightdm_installed(Command):
-    assert Command('lightdm --version').rc == 0
+def test_lightdm_installed(host):
+    assert host.run('lightdm --version').rc == 0
 
 
-def test_config_file(File):
-    conf = File('/usr/share/lightdm/lightdm.conf.d/70-ansible.conf')
+def test_config_file(host):
+    conf = host.file('/usr/share/lightdm/lightdm.conf.d/70-ansible.conf')
 
     assert conf.exists
     assert conf.is_file
@@ -20,8 +20,8 @@ def test_config_file(File):
     assert oct(conf.mode) == '0644'
 
 
-def test_auto_login(File):
-    conf = File('/usr/share/lightdm/lightdm.conf.d/70-ansible.conf')
+def test_auto_login(host):
+    conf = host.file('/usr/share/lightdm/lightdm.conf.d/70-ansible.conf')
 
     assert conf.exists
     assert conf.is_file
@@ -29,8 +29,8 @@ def test_auto_login(File):
     assert conf.contains('autologin-user-timeout=4242')
 
 
-def test_guest_login(File):
-    conf = File('/usr/share/lightdm/lightdm.conf.d/70-ansible.conf')
+def test_guest_login(host):
+    conf = host.file('/usr/share/lightdm/lightdm.conf.d/70-ansible.conf')
 
     assert conf.exists
     assert conf.is_file

--- a/molecule/no-login/tests/test_role.py
+++ b/molecule/no-login/tests/test_role.py
@@ -6,12 +6,12 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
     os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('all')
 
 
-def test_lightdm_installed(Command):
-    assert Command('lightdm --version').rc == 0
+def test_lightdm_installed(host):
+    assert host.run('lightdm --version').rc == 0
 
 
-def test_config_file(File):
-    conf = File('/usr/share/lightdm/lightdm.conf.d/70-ansible.conf')
+def test_config_file(host):
+    conf = host.file('/usr/share/lightdm/lightdm.conf.d/70-ansible.conf')
 
     assert conf.exists
     assert conf.is_file
@@ -20,8 +20,8 @@ def test_config_file(File):
     assert oct(conf.mode) == '0644'
 
 
-def test_auto_login(File):
-    conf = File('/usr/share/lightdm/lightdm.conf.d/70-ansible.conf')
+def test_auto_login(host):
+    conf = host.file('/usr/share/lightdm/lightdm.conf.d/70-ansible.conf')
 
     assert conf.exists
     assert conf.is_file
@@ -29,8 +29,8 @@ def test_auto_login(File):
     assert not conf.contains('autologin-user-timeout')
 
 
-def test_guest_login(File):
-    conf = File('/usr/share/lightdm/lightdm.conf.d/70-ansible.conf')
+def test_guest_login(host):
+    conf = host.file('/usr/share/lightdm/lightdm.conf.d/70-ansible.conf')
 
     assert conf.exists
     assert conf.is_file


### PR DESCRIPTION
Other fixtures are deprecated and will be removed in 2.0 Testinfra release.