### PR TITLE
Clarified Ubuntu Trusty support

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Requirements
 
         * Ubuntu
 
+            * Trusty (14.04)
             * Xenial (16.04)
 
         * Note: other versions are likely to work but have not been tested.

--- a/molecule/no-login/molecule.yml
+++ b/molecule/no-login/molecule.yml
@@ -10,7 +10,7 @@ lint:
 
 platforms:
   - name: ansible-role-lightdm-no-login
-    image: ubuntu:16.04
+    image: ubuntu:14.04
 
 provisioner:
   name: ansible


### PR DESCRIPTION
It was in the metadata but not in the `README.md`.