### PR TITLE
Resolved apt module syntax deprecation warning

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,11 +2,10 @@
 - name: install dependencies (apt)
   become: yes
   apt:
-    name: '{{ item }}'
+    name:
+      - lightdm
+      - libglib2.0-bin
     state: present
-  with_items:
-    - lightdm
-    - libglib2.0-bin
   when: ansible_pkg_mgr == 'apt'
 
 - name: write LightDM configuration


### PR DESCRIPTION
```
[DEPRECATION WARNING]: Invoking "apt" only once while using a loop via
squash_actions is deprecated. Instead of using a loop to supply multiple items
and specifying `name: {{ item }}`, please use `name: [u'lightdm',
u'libglib2.0-bin']` and remove the loop. This feature will be removed in
version 2.11. Deprecation warnings can be disabled by setting
deprecation_warnings=False in ansible.cfg.
```