### PR TITLE
Updated Travis CI config to use jobs key instead of matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ env:
 
 # Spin off separate builds for each of the following versions
 # of Ansible and Linux.
-matrix:
+jobs:
   include:
     - env:
         - MOLECULE_SCENARIO=default


### PR DESCRIPTION
`jobs` is the new preferred name.