### PR TITLE
Increased minimum Ansible version to 2.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,10 @@ jobs:
   include:
     - env:
         - MOLECULE_SCENARIO=default
-        - MOLECULEW_ANSIBLE=2.7.15
+        - MOLECULEW_ANSIBLE=2.8.16
     - env:
         - MOLECULE_SCENARIO=default
-        - MOLECULEW_ANSIBLE=2.7.15
+        - MOLECULEW_ANSIBLE=2.8.16
     - env:
         - MOLECULE_SCENARIO=no-login
         - MOLECULEW_ANSIBLE=2.9.1

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Requirements
 
 * LightDM installed
 
-* Ansible >= 2.7
+* Ansible >= 2.8
 
 * Linux Distribution
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -5,7 +5,7 @@ galaxy_info:
   description: Role for configuring LightDM.
   company: GantSign Ltd.
   license: MIT
-  min_ansible_version: 2.7
+  min_ansible_version: 2.8
   platforms:
     - name: Ubuntu
       versions:


### PR DESCRIPTION
Ansible no longer supports versions earlier than 2.8.