### PR TITLE
Dropped support for Ubuntu Xenial

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ Requirements
 
         * Ubuntu
 
-            * Xenial (16.04)
             * Bionic (16.04)
             * Focal (20.04)
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -9,7 +9,6 @@ galaxy_info:
   platforms:
     - name: Ubuntu
       versions:
-        - xenial
         - bionic
         - focal
   galaxy_tags:

--- a/molecule/no-login/molecule.yml
+++ b/molecule/no-login/molecule.yml
@@ -13,7 +13,7 @@ lint: |
 
 platforms:
   - name: ansible-role-lightdm-no-login
-    image: ubuntu:16.04
+    image: ubuntu:18.04
     dockerfile: ../default/Dockerfile.j2
 
 provisioner:


### PR DESCRIPTION
Canonical have ended standard support for Ubuntu Xenial.